### PR TITLE
FIX update profile error #125

### DIFF
--- a/project/frontend/src/pages/User/SettingsPage.vue
+++ b/project/frontend/src/pages/User/SettingsPage.vue
@@ -145,12 +145,10 @@ export default {
         updateProfile() {
             this.usernameNullCheck();
 
-            let uploadedImage;
+            let uploadedImage = null;
             if (this.$refs.imageUploader.selectedImage !== null) {
                 // 新しい画像が入力されていたらそれを採用する
                 uploadedImage = this.$refs.imageUploader.selectedImage;
-            } else {
-                uploadedImage = this.userDetail.prof_img;
             }
 
             // userDetailの更新


### PR DESCRIPTION
画像未変更時は画像の更新を行わないようにする。
DBで保存されている画像フォーマットと更新データとして渡す画像フォーマットが異なるため。